### PR TITLE
Fix issue: KinesisVideoRekognitionIntegrationExample broken (#52)

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,9 @@ To run the sample follow the below steps:
  the new Kinesis Video stream might be delayed significantly.
 
 ## Release Notes
+### Release 1.0.11 (Mar 2019)
+* Bugfix: KinesisVideoRekognitionIntegrationExample broken because the frame process callback is not invoked.
+
 ### Release 1.0.10 (Feb 2019)
 * Bugfix: Close GetMedia connection to fix the connection leak issue.
 

--- a/src/main/java/com/amazonaws/kinesisvideo/parser/utilities/H264BoundingBoxFrameRenderer.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/parser/utilities/H264BoundingBoxFrameRenderer.java
@@ -54,7 +54,8 @@ public class H264BoundingBoxFrameRenderer extends H264FrameRenderer {
     }
 
     @Override
-    public void process(final Frame frame, final MkvTrackMetadata trackMetadata, final Optional<FragmentMetadata> fragmentMetadata) {
+    public void process(final Frame frame, final MkvTrackMetadata trackMetadata, final Optional<FragmentMetadata> fragmentMetadata,
+                        final Optional<FragmentMetadataVisitor.MkvTagProcessor> tagProcessor) {
         final BufferedImage bufferedImage = decodeH264Frame(frame, trackMetadata);
         final Optional<RekognizedOutput> rekognizedOutput = getRekognizedOutput(frame, fragmentMetadata);
         renderFrame(bufferedImage, rekognizedOutput);


### PR DESCRIPTION
Fix issue that process callback method is not called

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
